### PR TITLE
Updated html5 video bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
   <body>
     <p>Allow this website to use your webcam, then place your finger lightly over the camera and wait for the trace to stabilise.</p>
     <p>You will have most success when there is light behind your finger.</p>
-    <video id="v" width="100" height="100" style="display:none"></video>
+    <video id="v" width="100" height="100" style="display:none" muted></video>
     <canvas id="c" width="100" height="100" style="display:none"></canvas>
     <canvas id="g" width="320" height="30"></canvas><br/>
     <div id="bpm">--</div>


### PR DESCRIPTION
The Autoplay Policy launched in M66 Stable for audio and video elements and is effectively blocking roughly half of unwanted media autoplays in Chrome. This bug fix mutes the video player so chrome does not block it from starting. More info can be found here: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes